### PR TITLE
Dependency inversion principle - SearchTravelPackageService

### DIFF
--- a/GoTorz.Client/Pages/SearchTravelPackage.razor
+++ b/GoTorz.Client/Pages/SearchTravelPackage.razor
@@ -1,7 +1,8 @@
 ﻿@page "/search"
-@inject SearchTravelPackageService SearchService
+@inject ISearchTravelPackageService SearchService
 @inject NavigationManager Navigation
 @using GoTorz.Client.Components
+@using GoTorz.Client.Services.Interfaces
 
 <link rel="stylesheet" href="css/search.css" />
 

--- a/GoTorz.Client/Program.cs
+++ b/GoTorz.Client/Program.cs
@@ -15,7 +15,7 @@ namespace GoTorz.Client
             builder.RootComponents.Add<HeadOutlet>("head::after");
             
             //service
-            builder.Services.AddScoped<SearchTravelPackageService>();
+            builder.Services.AddScoped<ISearchTravelPackageService, SearchTravelPackageService>();
 
 
             // Http


### PR DESCRIPTION
Replaced direct injection of SearchTravelPackageService implementation with the ISearchTravelPackageService interface in SearchTravelPackage.razor.

Updated service registration in Program.cs to use interface-based DI

Why:
Promotes loose coupling and improves testability.
Follows best practices by depending on abstractions rather than concrete implementations.

Files Affected:
SearchTravelPackage.razor
Program.cs

Next Steps: We should apply the same pattern to other services — including Authentication & Authorization — to consistently follow DIP and SOLID principles across the project.