### PR TITLE
Move secrets to .env and inject configuration in controllers

### DIFF
--- a/src/GoTorz.Api/Controllers/DestinationController.cs
+++ b/src/GoTorz.Api/Controllers/DestinationController.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using GoTorz.Shared.DTOs;
-using System.Net.Http;
+﻿using GoTorz.Shared.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 namespace GoTorz.Api.Controllers
@@ -9,7 +9,12 @@ namespace GoTorz.Api.Controllers
     [Route("api/[controller]")]
     public class DestinationController : ControllerBase
     {
-        readonly string ApiKey = "f63472ff3dmsh48a6a25a8a05abap1790dcjsn7ea0f9022bcc";
+        private readonly RapidApiSettings _rapidApiSettings;
+
+        public DestinationController(IOptions<RapidApiSettings> rapidApiSettings)
+        {
+            _rapidApiSettings = rapidApiSettings.Value;
+        }
 
         [HttpGet]
         public async Task<IActionResult> SearchDestination([FromQuery] string query = "man")
@@ -27,8 +32,8 @@ namespace GoTorz.Api.Controllers
                 RequestUri = new Uri(url),
                 Headers =
                 {
-                    { "x-rapidapi-key", ApiKey },
-                    { "x-rapidapi-host", "booking-com15.p.rapidapi.com" },
+                    { "x-rapidapi-key", _rapidApiSettings.ApiKey },
+                    { "x-rapidapi-host", _rapidApiSettings.Host },
                 },
             };
 

--- a/src/GoTorz.Api/Controllers/FlightDestinationController.cs
+++ b/src/GoTorz.Api/Controllers/FlightDestinationController.cs
@@ -1,5 +1,6 @@
 ﻿using GoTorz.Shared.DTOs;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 namespace GoTorz.Api.Controllers
@@ -8,7 +9,12 @@ namespace GoTorz.Api.Controllers
     [Route("api/[controller]")]
     public class FlightsController : ControllerBase
     {
-        private readonly string ApiKey = "f63472ff3dmsh48a6a25a8a05abap1790dcjsn7ea0f9022bcc";
+        private readonly RapidApiSettings _rapidApiSettings;
+
+        public FlightsController(IOptions<RapidApiSettings> rapidApiSettings)
+        {
+            _rapidApiSettings = rapidApiSettings.Value;
+        }
 
         [HttpGet("search-flight-destinations")]
         public async Task<IActionResult> SearchFlightDestinations([FromQuery] string query)
@@ -24,8 +30,8 @@ namespace GoTorz.Api.Controllers
                 RequestUri = new Uri(url),
                 Headers =
             {
-                { "x-rapidapi-key", ApiKey },
-                { "x-rapidapi-host", "booking-com15.p.rapidapi.com" },
+                { "x-rapidapi-key", _rapidApiSettings.ApiKey },
+                { "x-rapidapi-host", _rapidApiSettings.Host },
             },
             };
 

--- a/src/GoTorz.Api/Controllers/FlightSearchController.cs
+++ b/src/GoTorz.Api/Controllers/FlightSearchController.cs
@@ -1,5 +1,6 @@
 ﻿using GoTorz.Shared.DTOs;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 namespace GoTorz.Api.Controllers
@@ -8,7 +9,12 @@ namespace GoTorz.Api.Controllers
     [Route("api/[controller]")]
     public class FlightSearchController : ControllerBase
     {
-        private readonly string ApiKey = "f63472ff3dmsh48a6a25a8a05abap1790dcjsn7ea0f9022bcc";
+        private readonly RapidApiSettings _rapidApiSettings;
+
+        public FlightSearchController(IOptions<RapidApiSettings> rapidApiSettings)
+        {
+            _rapidApiSettings = rapidApiSettings.Value;
+        }
 
         [HttpGet("search-flights")]
         public async Task<IActionResult> SearchFlights(
@@ -33,8 +39,8 @@ namespace GoTorz.Api.Controllers
                     RequestUri = new Uri(url),
                     Headers =
                     {
-                        { "x-rapidapi-key", ApiKey },
-                        { "x-rapidapi-host", "booking-com15.p.rapidapi.com" },
+                        { "x-rapidapi-key", _rapidApiSettings.ApiKey },
+                        { "x-rapidapi-host", _rapidApiSettings.Host },
                     },
                 };
 

--- a/src/GoTorz.Api/Controllers/HotelController.cs
+++ b/src/GoTorz.Api/Controllers/HotelController.cs
@@ -1,5 +1,6 @@
 ﻿using GoTorz.Shared.DTOs;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 namespace GoTorz.Api.Controllers
@@ -8,7 +9,12 @@ namespace GoTorz.Api.Controllers
     [Route("api/[controller]")]
     public class HotelsController : ControllerBase
     {
-        private readonly string ApiKey = "f63472ff3dmsh48a6a25a8a05abap1790dcjsn7ea0f9022bcc";
+        private readonly RapidApiSettings _rapidApiSettings;
+
+        public HotelsController(IOptions<RapidApiSettings> rapidApiSettings)
+        {
+            _rapidApiSettings = rapidApiSettings.Value;
+        }
 
         [HttpGet("search-hotels")]
         public async Task<IActionResult> SearchHotels(
@@ -35,8 +41,8 @@ namespace GoTorz.Api.Controllers
                 RequestUri = new Uri(url),
                 Headers =
                 {
-                    { "x-rapidapi-key", ApiKey },
-                    { "x-rapidapi-host", "booking-com15.p.rapidapi.com" },
+                    { "x-rapidapi-key", _rapidApiSettings.ApiKey },
+                    { "x-rapidapi-host", _rapidApiSettings.Host },
                 },
             };
 

--- a/src/GoTorz.Api/GoTorz.Api.csproj
+++ b/src/GoTorz.Api/GoTorz.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.14" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />

--- a/src/GoTorz.Api/Program.cs
+++ b/src/GoTorz.Api/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Stripe;
+using DotNetEnv;
 
 namespace GoTorz.Api
 {
@@ -14,8 +15,10 @@ namespace GoTorz.Api
     {
         public static void Main(string[] args)
         {
-            var builder = WebApplication.CreateBuilder(args);
+            Env.Load();
 
+            var builder = WebApplication.CreateBuilder(args);
+            
             // Add services to the container.
             //travelPackage builders
             builder.Services.AddScoped<ITravelPackageRepository, TravelPackageRepository>();

--- a/src/GoTorz.Api/appsettings.json
+++ b/src/GoTorz.Api/appsettings.json
@@ -14,20 +14,20 @@
   "JwtSettings": {
     "Issuer": "GoTorz.Api",
     "Audience": "GoTorz.Client",
-    "SecretKey": "THIS_KEY_IS_VALID_UNTIL_MY_IMPOSTER_SYNDROME_EXPIRES",
+    "SecretKey": "<JwtSecret>",
     "ExpiryMinutes": 30
   },
 
   "RapidApiSettings": {
-    "ApiKey": "f63472ff3dmsh48a6a25a8a05abap1790dcjsn7ea0f9022bcc",
+    "ApiKey": "<RapidApiKey>",
     "Host": "booking-com15.p.rapidapi.com"
   },
 
   "Stripe": {
-    "SecretKey": "sk_test_51REtwnD1Z05o2cvI5eMepfaT9Wjs0gilkSoLACBGnRxvT0fjHrtYeNSShTxjVtoIvcQA45Ud4bb9hpsZwpjSEM2v00T19VWK0Q"
+    "SecretKey": "<StripeSecretKey>"
   },
+
   "AppSettings": {
     "BaseUrl": "https://localhost:7272"
   }
-
-  }
+}


### PR DESCRIPTION
### Summary
- Moved all sensitive values from `appsettings.json` to `.env` (not committed)
- Injected `RapidApiSettings` into all controllers using `IOptions<T>`
- Removed all hardcoded API keys from controllers
- Added `DotNetEnv.Env.Load()` in `Program.cs` to support local environment-based config
- Verified that JWT login works with secret loaded from `.env`

### Notes
- This PR sets up secure, environment-driven configuration for development
- Docker and production will handle environment variables differently (later PRs)
- Next: move logic from controllers into service classes
