### PR TITLE
Implement automatic identity seeding during app startup

### DIFF
--- a/src/GoTorz.Api/Data/IdentitySeeder.cs
+++ b/src/GoTorz.Api/Data/IdentitySeeder.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace GoTorz.API.Data
+{
+    public static class IdentitySeeder
+    {
+        public static async Task SeedAsync(UserManager<IdentityUser> userManager, RoleManager<IdentityRole> roleManager)
+        {
+            // Define the users to be seeded
+            var users = new[]
+            {
+                new { Email = "1@1", Password = "1", Role = "Admin" },
+                new { Email = "2@2", Password = "2", Role = "SalesRep" },
+                new { Email = "3@3", Password = "3", Role = "User" },
+            };
+
+            // Ensure roles exist, create them if they don't
+            var roles = new[] { "Admin", "SalesRep", "User" };
+            foreach (var role in roles)
+            {
+                if (await roleManager.RoleExistsAsync(role) == false)
+                {
+                    await roleManager.CreateAsync(new IdentityRole(role));
+                }
+            }
+
+            // Loop through users and create them if they don't already exist
+            foreach (var entry in users)
+            {
+                if (await userManager.FindByEmailAsync(entry.Email) is null)
+                {
+                    var user = new IdentityUser { UserName = entry.Email, Email = entry.Email };
+                    var result = await userManager.CreateAsync(user, entry.Password);
+                    if (result.Succeeded)
+                    {
+                        await userManager.AddToRoleAsync(user, entry.Role);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/GoTorz.Api/Program.cs
+++ b/src/GoTorz.Api/Program.cs
@@ -10,12 +10,13 @@ using Stripe;
 using DotNetEnv;
 using Microsoft.Extensions.Options;
 using GoTorz.Api.Adapters;
+using GoTorz.API.Data;
 
 namespace GoTorz.Api
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             Env.Load();
 
@@ -118,6 +119,14 @@ namespace GoTorz.Api
 
             var app = builder.Build();
 
+            // Ensure roles and users are seeded before the app runs
+            using (var scope = app.Services.CreateScope())
+            {
+                var services = scope.ServiceProvider;
+                var userManager = services.GetRequiredService<UserManager<IdentityUser>>();
+                var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
+                await IdentitySeeder.SeedAsync(userManager, roleManager);  // Run the seeder
+            }
 
             // Configure the HTTP request pipeline. 
             if (app.Environment.IsDevelopment())


### PR DESCRIPTION
### Description:
This PR adds an automatic identity seeding mechanism during the application startup. The following changes were made:

- Added **seeding logic** to create default users and roles (`Admin`, `SalesRep`, `User`) on application startup.
- The **IdentitySeeder** checks if the users and roles already exist and only creates them if they do not exist in the database.
- Ensured that the seeding runs **before** the application starts accepting HTTP requests, guaranteeing the necessary data is available.

This allows users to run the application without manually creating users or roles. The seeding logic is executed once on app startup and is idempotent.

### Testing:
- Deleted all existing users and roles from the database.
- Ran the application to verify that roles and users were automatically created.
- Ensured that the login functionality works with the default test users (`1@1`, `2@2`, `3@3`).
