### PR TITLE
chore: add .dockerignore files to API and Client

### DIFF
--- a/src/GoTorz.Api/.dockerignore
+++ b/src/GoTorz.Api/.dockerignore
@@ -1,0 +1,27 @@
+# Ignore build artifacts
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+
+# Ignore environment secrets
+.env
+*.env
+
+# Ignore Git and IDE files
+.git
+.vs
+.vscode
+
+# Ignore test results and logs
+TestResults/
+*.log
+*.trx
+
+# Ignore node_modules (if any)
+node_modules/
+
+# OS metadata
+Thumbs.db
+.DS_Store

--- a/src/GoTorz.Client/.dockerignore
+++ b/src/GoTorz.Client/.dockerignore
@@ -1,0 +1,27 @@
+# Ignore build artifacts
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+
+# Ignore environment secrets
+.env
+*.env
+
+# Ignore Git and IDE files
+.git
+.vs
+.vscode
+
+# Ignore test results and logs
+TestResults/
+*.log
+*.trx
+
+# Ignore node_modules (if any)
+node_modules/
+
+# OS metadata
+Thumbs.db
+.DS_Store


### PR DESCRIPTION
Adds `.dockerignore` files to both GoTorz.API and GoTorz.Client.
These files exclude build artifacts, secrets, and other unnecessary files from Docker images.
