### PR TITLE
Fix CORS policy and Dockerfile API base URL injection for GoTorz Client deployment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,18 @@ jobs:
           name: coverage-report
           path: coveragereport
 
+      # Build docker containers
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image - API
+        run: |
+          docker build -t gotorz-api-test -f src/GoTorz.API/Dockerfile src/GoTorz.API
+
+      - name: Build Docker image - Client
+        run: |
+          docker build -t gotorz-client-test -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
+
 
 # We push manually because our Azure Student Accounts do not have access to app registrations which is needed to make github push images automatically
 # cd:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,12 +63,12 @@ jobs:
 
       - name: Build and tag API image
         run: |
-          docker build -t gotorzacr.azurecr.io/gotorz-api:latest -f src/GoTorz.API/Dockerfile src/GoTorz.API
+          docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest -f src/GoTorz.API/Dockerfile src/GoTorz.API
 
       - name: Build and tag Client image
         run: |
-          docker build -t gotorzacr.azurecr.io/gotorz-client:latest -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
+          docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-client:latest -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
 
       # You must push manually from local machine until ACR login is configured
-      # docker push gotorzacr.azurecr.io/gotorz-api:latest
-      # docker push gotorzacr.azurecr.io/gotorz-client:latest
+      # docker push gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest
+      # docker push gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-client:latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,30 +42,16 @@ jobs:
           name: coverage-report
           path: coveragereport
 
-      # Build docker containers
+  cd:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    name: CD - Manual Docker Push
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image - API
-        run: |
-          docker build -t gotorz-api-test -f src/GoTorz.API/Dockerfile src/GoTorz.API
-
-      - name: Build Docker image - Client
-        run: |
-          docker build -t gotorz-client-test -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
-
-
-# We push manually because our Azure Student Accounts do not have access to app registrations which is needed to make github push images automatically
-# cd:
- #  if: github.ref == 'refs/heads/main'
-  # runs-on: ubuntu-latest
-   # name: CD - (disabled) Manual Docker Push instead
-     # steps:
-      # - name: Checkout code
-      #  uses: actions/checkout@v4
-
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
 
       # - name: Log in to Azure
       #   uses: azure/login@v2
@@ -75,14 +61,14 @@ jobs:
       # - name: Log in to ACR
       #   run: az acr login --name gotorzacr
 
-      # - name: Build and push API image
-      #   run: |
-      #     docker build -t gotorzacr.azurecr.io/gotorz-api:latest -f GoTorz.API/Dockerfile .
-      #     docker push gotorzacr.azurecr.io/gotorz-api:latest
+      - name: Build and tag API image
+        run: |
+          docker build -t gotorzacr.azurecr.io/gotorz-api:latest -f src/GoTorz.API/Dockerfile src/GoTorz.API
 
-      # - name: Build and push Client image
-      #   run: |
-      #     docker build -t gotorzacr.azurecr.io/gotorz-client:latest -f GoTorz.Client/Dockerfile .
-      #     docker push gotorzacr.azurecr.io/gotorz-client:latest
+      - name: Build and tag Client image
+        run: |
+          docker build -t gotorzacr.azurecr.io/gotorz-client:latest -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
 
-
+      # You must push manually from local machine until ACR login is configured
+      # docker push gotorzacr.azurecr.io/gotorz-api:latest
+      # docker push gotorzacr.azurecr.io/gotorz-client:latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,9 +65,13 @@ jobs:
         run: |
           docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest -f src/GoTorz.API/Dockerfile src/GoTorz.API
 
-      - name: Build and tag Client image
+      - name: Build and tag Client image (hardcoded URL)
         run: |
-          docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-client:latest -f src/GoTorz.Client/Dockerfile src/GoTorz.Client
+          docker build \
+          --build-arg API_BASE_URL=https://gotorz-api-app-h6ejandxdcg6ccdt.swedencentral-01.azurewebsites.net \
+          -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-client:latest \
+          -f src/GoTorz.Client/Dockerfile \
+          src/GoTorz.Client
 
       # You must push manually from local machine until ACR login is configured
       # docker push gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest

--- a/src/GoTorz.Api/.dockerignore
+++ b/src/GoTorz.Api/.dockerignore
@@ -1,0 +1,27 @@
+# Ignore build artifacts
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+
+# Ignore environment secrets
+.env
+*.env
+
+# Ignore Git and IDE files
+.git
+.vs
+.vscode
+
+# Ignore test results and logs
+TestResults/
+*.log
+*.trx
+
+# Ignore node_modules (if any)
+node_modules/
+
+# OS metadata
+Thumbs.db
+.DS_Store

--- a/src/GoTorz.Api/Controllers/TravelPackagesController.cs
+++ b/src/GoTorz.Api/Controllers/TravelPackagesController.cs
@@ -1,6 +1,7 @@
 ﻿using GoTorz.Api.Data;
 using GoTorz.Api.Services;
 using GoTorz.Shared.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GoTorz.Api.Controllers
@@ -31,6 +32,7 @@ namespace GoTorz.Api.Controllers
             return Ok(package);
         }
 
+        [Authorize(Roles = "Admin,SalesRep")]
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] TravelPackage package)
         {
@@ -38,6 +40,7 @@ namespace GoTorz.Api.Controllers
             return Ok();
         }
 
+        [Authorize(Roles = "Admin,SalesRep")]
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(string id)
         {

--- a/src/GoTorz.Api/Program.cs
+++ b/src/GoTorz.Api/Program.cs
@@ -21,7 +21,10 @@ namespace GoTorz.Api
             Env.Load();
 
             var builder = WebApplication.CreateBuilder(args);
-            
+
+            // Retrieve BaseUrl from appsettings.json
+            var apiBaseUrl = builder.Configuration.GetValue<string>("AppSettings:BaseUrl") ?? "https://localhost:7111";  // Default to localhost for dev
+
             // Add services to the container.       
 
             // DbContext

--- a/src/GoTorz.Api/Program.cs
+++ b/src/GoTorz.Api/Program.cs
@@ -112,7 +112,8 @@ namespace GoTorz.Api
                             "https://localhost:7272"
                         )
                           .AllowAnyHeader()
-                          .AllowAnyMethod();
+                          .AllowAnyMethod()
+                          .AllowCredentials(); // If using cookies/auth
                 });
             });
 
@@ -127,17 +128,11 @@ namespace GoTorz.Api
             builder.Services.AddScoped<IPaymentAdapter, StripePaymentAdapter>();
             builder.Services.AddScoped<IBookingRepository, BookingRepository>();
 
-
-
-
-
-
             // External App Services (via HTTP)
             builder.Services.AddScoped<IBookingService, BookingService>(); // Stripe SDK internally uses HTTP - so external       
             builder.Services.AddHttpClient<IFlightApiAdapter, RapidApiFlightAdapter>();
             builder.Services.AddHttpClient<IHotelApiAdapter, RapidApiHotelAdapter>();
             builder.Services.AddHttpClient<IDestinationApiAdapter, RapidApiDestinationAdapter>();
-
 
             // System-level Services (HttpContextAccessor - for getting the current user)
             builder.Services.AddHttpContextAccessor();
@@ -154,6 +149,7 @@ namespace GoTorz.Api
                 var services = scope.ServiceProvider;
                 var userManager = services.GetRequiredService<UserManager<IdentityUser>>();
                 var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
+                Console.WriteLine("Running IdentitySeeder.SeedAsync...");
                 await IdentitySeeder.SeedAsync(userManager, roleManager);  // Run the seeder
             }
 

--- a/src/GoTorz.Api/appsettings.json
+++ b/src/GoTorz.Api/appsettings.json
@@ -28,6 +28,6 @@
   },
 
   "AppSettings": {
-    "BaseUrl": "https://localhost:7272"
+    "BaseUrl": "https://gotorz-api-app-h6ejandxdcg6ccdt.swedencentral-01.azurewebsites.net"
   }
 }

--- a/src/GoTorz.Api/dockerfile
+++ b/src/GoTorz.Api/dockerfile
@@ -2,14 +2,19 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-# Copy solution and restore dependencies
-COPY *.sln .
-COPY GoTorz.API/GoTorz.API.csproj GoTorz.API/
+# Copy solution and all source folders
+COPY . .
+
+# Restore dependencies
 RUN dotnet restore
 
-# Copy everything and build
-COPY GoTorz.API/ GoTorz.API/
-WORKDIR /src/GoTorz.API
+# Copy all source code
+COPY src/GoTorz.Api/ GoTorz.Api/
+COPY src/GoTorz.Client/ GoTorz.Client/
+COPY src/GoTorz.Shared/ GoTorz.Shared/
+
+# Publish the API project
+WORKDIR /src/GoTorz.Api
 RUN dotnet publish -c Release -o /app/publish
 
 # Stage 2: Runtime
@@ -20,4 +25,4 @@ COPY --from=build /app/publish .
 EXPOSE 8080
 ENV ASPNETCORE_URLS=http://+:8080
 
-ENTRYPOINT ["dotnet", "GoTorz.API.dll"]
+ENTRYPOINT ["dotnet", "GoTorz.Api.dll"]

--- a/src/GoTorz.Client/.dockerignore
+++ b/src/GoTorz.Client/.dockerignore
@@ -1,0 +1,27 @@
+# Ignore build artifacts
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+
+# Ignore environment secrets
+.env
+*.env
+
+# Ignore Git and IDE files
+.git
+.vs
+.vscode
+
+# Ignore test results and logs
+TestResults/
+*.log
+*.trx
+
+# Ignore node_modules (if any)
+node_modules/
+
+# OS metadata
+Thumbs.db
+.DS_Store

--- a/src/GoTorz.Client/Program.cs
+++ b/src/GoTorz.Client/Program.cs
@@ -25,10 +25,13 @@ namespace GoTorz.Client
 
 
             // Http
-            builder.Configuration.AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
+            var apiBaseUrl = "__API_BASE_URL__";
 
-            var apiBaseUrl = builder.Configuration["ApiBaseUrl"]
-                ?? throw new InvalidOperationException("Missing ApiBaseUrl in configuration.");
+            // Use localhost for local dev if not replaced
+            if (apiBaseUrl == "__API_BASE_URL__")
+            {
+                apiBaseUrl = "https://localhost:7111/";
+            }
 
             builder.Services.AddScoped(sp =>
                 new HttpClient { BaseAddress = new Uri(apiBaseUrl) });

--- a/src/GoTorz.Client/Program.cs
+++ b/src/GoTorz.Client/Program.cs
@@ -25,12 +25,13 @@ namespace GoTorz.Client
 
 
             // Http
-            var apiBaseUrl = "__API_BASE_URL__" == "__API_BASE_URL__" // Looks weird but we inject value with dockerfile and PS command
-                ? "https://localhost:7111/"
-                : "__API_BASE_URL__";
+            var rawApiBaseUrl = "__API_BASE_URL__";
+            var apiBaseUrl = rawApiBaseUrl == "__API_BASE_URL__"
+             ? "https://localhost:7111/"
+             : rawApiBaseUrl;
 
             builder.Services.AddScoped(sp =>
-                new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
+             new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
 
 
 

--- a/src/GoTorz.Client/Program.cs
+++ b/src/GoTorz.Client/Program.cs
@@ -25,13 +25,9 @@ namespace GoTorz.Client
 
 
             // Http
-            var apiBaseUrl = "__API_BASE_URL__";
-
-            // Use localhost for local dev if not replaced
-            if (apiBaseUrl == "__API_BASE_URL__")
-            {
-                apiBaseUrl = "https://localhost:7111/";
-            }
+            var apiBaseUrl = "__API_BASE_URL__" == "__API_BASE_URL__" // Looks weird but we inject value with dockerfile and PS command
+                ? "https://localhost:7111/"
+                : "__API_BASE_URL__";
 
             builder.Services.AddScoped(sp =>
                 new HttpClient { BaseAddress = new Uri(apiBaseUrl) });
@@ -51,7 +47,7 @@ namespace GoTorz.Client
             builder.Services.AddScoped<CustomAuthStateProvider>();
             builder.Services.AddScoped<ICustomAuthStateProvider>(sp => sp.GetRequiredService<CustomAuthStateProvider>());
             builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<CustomAuthStateProvider>()); // Inject this in components (not the interface or concrete type)
-            builder.Services.AddScoped<IClientAuthService, ClientAuthService>();           
+            builder.Services.AddScoped<IClientAuthService, ClientAuthService>();
             builder.Services.AddAuthorizationCore();
 
             await builder.Build().RunAsync();

--- a/src/GoTorz.Client/dockerfile
+++ b/src/GoTorz.Client/dockerfile
@@ -12,6 +12,11 @@ RUN sed -i "s|__API_BASE_URL__|${API_BASE_URL}|" ./src/GoTorz.Client/Program.cs
 # Restore dependencies
 RUN dotnet restore
 
+# Copy all source code
+COPY src/GoTorz.Api/ GoTorz.Api/
+COPY src/GoTorz.Client/ GoTorz.Client/
+COPY src/GoTorz.Shared/ GoTorz.Shared/
+
 # Publish the Client project
 WORKDIR /src/GoTorz.Client
 RUN dotnet publish -c Release -o /app/publish

--- a/src/GoTorz.Client/dockerfile
+++ b/src/GoTorz.Client/dockerfile
@@ -5,30 +5,25 @@ WORKDIR /src
 # Copy solution and all source folders
 COPY . .
 
-# Inject the actual API base URL into the Blazor WASM Program.cs
-ARG API_BASE_URL
-RUN sed -i "s|__API_BASE_URL__|${API_BASE_URL}|" ./src/GoTorz.Client/Program.cs
-
 # Restore dependencies
 RUN dotnet restore
 
-# Copy all source code
-COPY src/GoTorz.Api/ GoTorz.Api/
-COPY src/GoTorz.Client/ GoTorz.Client/
-COPY src/GoTorz.Shared/ GoTorz.Shared/
+# Inject API Base URL into Program.cs
+ARG API_BASE_URL
+RUN sed -i '0,/__API_BASE_URL__/s|__API_BASE_URL__|https://gotorz-api-app-h6ejandxdcg6ccdt.swedencentral-01.azurewebsites.net|' ./src/GoTorz.Client/Program.cs
 
 # Publish the Client project
-WORKDIR /src/GoTorz.Client
+WORKDIR /src/src/GoTorz.Client
 RUN dotnet publish -c Release -o /app/publish
 
 # Stage 2: Runtime
 FROM nginx:stable-alpine AS runtime
 WORKDIR /usr/share/nginx/html
 
-# Remove default nginx static content
+# Clean default nginx content
 RUN rm -rf ./*
 
-# Copy Blazor build output
+# Copy Blazor build output to nginx
 COPY --from=build /app/publish/wwwroot .
 
 EXPOSE 80

--- a/src/GoTorz.Client/dockerfile
+++ b/src/GoTorz.Client/dockerfile
@@ -5,13 +5,12 @@ WORKDIR /src
 # Copy solution and all source folders
 COPY . .
 
+# Inject the actual API base URL into the Blazor WASM Program.cs
+ARG API_BASE_URL
+RUN sed -i "s|__API_BASE_URL__|${API_BASE_URL}|" ./src/GoTorz.Client/Program.cs
+
 # Restore dependencies
 RUN dotnet restore
-
-# Copy all source code
-COPY src/GoTorz.Api/ GoTorz.Api/
-COPY src/GoTorz.Client/ GoTorz.Client/
-COPY src/GoTorz.Shared/ GoTorz.Shared/
 
 # Publish the Client project
 WORKDIR /src/GoTorz.Client

--- a/src/GoTorz.Client/dockerfile
+++ b/src/GoTorz.Client/dockerfile
@@ -2,13 +2,18 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
-# Copy solution and restore dependencies
-COPY *.sln .
-COPY GoTorz.Client/GoTorz.Client.csproj GoTorz.Client/
+# Copy solution and all source folders
+COPY . .
+
+# Restore dependencies
 RUN dotnet restore
 
-# Copy everything and build
-COPY GoTorz.Client/ GoTorz.Client/
+# Copy all source code
+COPY src/GoTorz.Api/ GoTorz.Api/
+COPY src/GoTorz.Client/ GoTorz.Client/
+COPY src/GoTorz.Shared/ GoTorz.Shared/
+
+# Publish the Client project
 WORKDIR /src/GoTorz.Client
 RUN dotnet publish -c Release -o /app/publish
 
@@ -16,10 +21,10 @@ RUN dotnet publish -c Release -o /app/publish
 FROM nginx:stable-alpine AS runtime
 WORKDIR /usr/share/nginx/html
 
-# Remove default nginx files
+# Remove default nginx static content
 RUN rm -rf ./*
 
-# Copy Blazor build artifacts
+# Copy Blazor build output
 COPY --from=build /app/publish/wwwroot .
 
 EXPOSE 80

--- a/src/GoTorz.Client/wwwroot/appsettings.json
+++ b/src/GoTorz.Client/wwwroot/appsettings.json
@@ -1,3 +1,0 @@
-﻿{
-  "ApiBaseUrl": "https://localhost:7111/"
-}


### PR DESCRIPTION
### Summary
This PR fixes deployment issues with the GoTorz Client by correcting how the API base URL is injected into the Blazor WebAssembly app during Docker build. Additionally, it ensures CORS credentials are allowed for authenticated requests.

### Changes:
- Added `.AllowCredentials()` to the CORS policy in GoTorz.API to support cookie/authenticated requests
- Simplified Dockerfile API base URL injection:
  - Fixed `sed` command to replace `__API_BASE_URL__` in `Program.cs`
  - Adjusted working directory paths to match correct source structure
  - Ensured Blazor build output is copied to Nginx correctly
- Refactored `Program.cs` API base URL logic:
  - Separated raw variable from evaluated value for clarity
  - Ensured correct API URL is used in production builds
- Removed redundant Docker COPY commands
- General cleanup of Dockerfile for consistency

### Result
- Client app now receives the correct API base URL in production
- Authenticated requests function correctly with CORS credentials
- Deployment flow for GoTorz Client is now reliable and matches Azure App Service setup
