### PR TITLE
Fix GitHub Actions to use 'master' branch for CI/CD workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: build-and-test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [master, develop]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   ci:
@@ -43,7 +43,7 @@ jobs:
           path: coveragereport
 
   cd:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     name: CD - Manual Docker Push
     steps:


### PR DESCRIPTION
### Summary
This PR updates the GitHub Actions workflow to use the `master` branch instead of `main` for both CI and CD processes. This ensures that the workflows align with the actual default branch used in the repository.

### Changes
- Updated `push` and `pull_request` triggers to reference `master`

### Notes
This is a minor but important fix to ensure automated builds and deployments run as expected.
