### PR TITLE
Fix Dockerfile path casing for CI/CD build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
   cd:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    name: CD - Manual Docker Push
+    name: CD - Build Docker Images (Manual Push Later)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build and tag API image
         run: |
-          docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest -f src/GoTorz.API/Dockerfile src/GoTorz.API
+          docker build -t gotorzacr-aadtajefbqhgcnda.azurecr.io/gotorz-api:latest -f src/GoTorz.Api/Dockerfile src/GoTorz.Api
 
       - name: Build and tag Client image (hardcoded URL)
         run: |


### PR DESCRIPTION
- Fixes path casing issue causing cd job to fail on GitHub Actions (Linux is case-sensitive).

- Renamed job to 'CD - Build Docker Images (Manual Push Later)' for clarity.